### PR TITLE
Fix type error description in step00c_type_error readme

### DIFF
--- a/step00c_type_error/readme.md
+++ b/step00c_type_error/readme.md
@@ -1,8 +1,10 @@
-# Syntax Error
+# Type Error
+
+To compile the TypeScript file, run the following command:
 
 		tsc app.ts
 
-The Output:
+The Output will be:
 
 		app.ts:2:9 - error TS2551: Property 'loger' does not exist on type 'Console'. Did you mean 'log'?
 
@@ -17,8 +19,5 @@ The Output:
 
 		Found 1 error in app.ts:2
 
-
-
-
-Note that .js file has been generated but it is not valid.
+Note that a .js file has been generated but it is not valid.
 


### PR DESCRIPTION
This pull request corrects the `readme.md` file in the `step00c_type_error` folder to accurately describe the error in the `app.ts` file as a type error instead of a syntax error. The error occurs due to the incorrect method `console.loger` instead of `console.log`.