### PR TITLE
Update inquirer version in readme.md with a note on versions

### DIFF
--- a/step03c_import_inquirer_ECMAScript_module/readme.md
+++ b/step03c_import_inquirer_ECMAScript_module/readme.md
@@ -3,10 +3,10 @@
 # Using Inquirer Package
 
 The latest version (9+) of [Inquirer](https://github.com/SBoudrias/Inquirer.js/) has start using Native ECMA Script Packages. In most of our projects and assignment we will use this package.
-
+Note: Inquirer versions 10+ are incompatible with how we use inquirer.prompt(). Version 10.0.0 gives error on using prompted variable as it has type unknown, and 10.1.0+ do not support our prompt usage entirely.
 Give the following command:
 
-        npm i inquirer
+        npm i inquirer@9.0.0
 
         npm i --save-dev @types/inquirer
 


### PR DESCRIPTION
Inquirer versions 10+ break our code in the following manner:
1. 10.0.0 does not allow using prompt's response as variable because the question was given unknown type
2. 10.1.0+ does not allow us to provide {message,type,name}[] type of prompt to inquirer.prompt(), making it completely incompatible